### PR TITLE
Responsive parent table

### DIFF
--- a/css/top.css
+++ b/css/top.css
@@ -1,4 +1,19 @@
+@media all and (max-width:1000px){
+    table{
+        width:100%;
+    }
 
+    td{
+        display:block;
+    }
+
+}
+
+@media all and (min-width:1000px){
+	.parent > tbody > tr > td{
+		width: 33%;
+	}
+}
 
 body {
   font-family: sans-serif;

--- a/top.html.erb
+++ b/top.html.erb
@@ -11,14 +11,8 @@
 
 <h1><%= site.title %></h1>
 
-<!-- use a table w/ three colums -->
-
-<table>
-  <colgroup>
-    <col width='33%'>
-    <col width='33%'>
-    <col width='33%'>
-  </colgroup>
+<!-- barely responsive table with default three columns -->
+<table class='parent'>
 <tr>
 
 <!-- check/fix: check if it will work w/o .all. - depreciated in rails 4+ -->


### PR DESCRIPTION
Make the parent table lose grid view on devices less that 1000px width.
On mobile phones the grid layout didn't appear very friendly.
I've little to no experience in front end dev, excuse me if the code is not up to the standards.
Do let me know if this feature is acceptable.

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>